### PR TITLE
fix(ci): comment-out go fix for now

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,4 +32,5 @@ jobs:
         # Check that go fmt ./... produces a zero diff; clean up any changes afterwards.
         go fmt ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code)
         # Check that go fix ./... produces a zero diff; clean up any changes afterwards.
-        go fix ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code)
+        # Uncomment the following line after updating to Go 1.23.x when go fix has been ... fixed
+        # go fix ./... && git diff --exit-code; code=$?; git checkout -- .; (exit $code)


### PR DESCRIPTION
https://github.com/golang/go/commit/7fd62ba821b1044e8e4077df052b0a1232672d57 is slated to land in Go 1.23 to fix... `go fix`